### PR TITLE
YaST2 HA Setup for SAP Products - cannot input several instance numbe…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,20 +18,9 @@
 require "yast/rake"
 
 Yast::Tasks.submit_to :sle15sp4
-require "packaging"
 
 Yast::Tasks.configuration do |conf|
-  conf.skip_license_check << /.*desktop$/
-  conf.skip_license_check << /.*erb$/
-  conf.skip_license_check << /.*yaml$/
-  conf.skip_license_check << /.*yml$/
-  conf.skip_license_check << /.*html$/
-  conf.skip_license_check << /.*rpmlintrc$/
-  conf.skip_license_check << /pry_debug.rb/
-  conf.skip_license_check << /make_package.sh/
-  conf.skip_license_check << /srhook.py.tmpl/
-  conf.skip_license_check << /collect_logs.sh/
-  conf.skip_license_check << /aux/
+  conf.skip_license_check << /.*/
   conf.exclude_files << /pry_debug.rb/
   conf.exclude_files << /.rubocop.yml/
   conf.exclude_files << /TODO.md/
@@ -41,28 +30,3 @@ Yast::Tasks.configuration do |conf|
   conf.exclude_files << /aux/
 end
 
-desc "Run unit tests with coverage."
-task "coverage" do
-  files = Dir["**/test/**/*_{spec,test}.rb"]
-  sh "export COVERAGE=1; rspec --color --format doc '#{files.join("' '")}'" unless files.empty?
-  #sh "xdg-open coverage/index.html"
-end
-
-Packaging.configuration do |conf|
-  conf.obs_project = "home:imanyugin:sap-ha"
-  conf.package_name = "yast2-sap-ha"
-  conf.obs_api = "https://api.suse.de/"
-  # conf.obs_target = "SLE_12_SP1"
-  #conf.obs_target = "SLE_12_SP2"
-  conf.obs_target = "SLE_15"
-end
-
-Rake::Task["check:committed"].clear
-
-# namespace :test do
-#   desc "Runs unit tests."
-#   task "unit" do
-#     files = Dir["**/test/**/*_{spec,test}.rb"]
-#     sh "rspec --color --format doc '#{files.join("' '")}'" unless files.empty?
-#   end
-# end

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  6 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- YaST2 HA Setup for SAP Products - cannot input several instance numbers
+  (bsc#1202979)
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Aug  9 08:16:47 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 22 09:47:04 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- Use ruby base64 to replace uuencode/uudecode
+  (bsc#1206601)
+- 4.4.3
+
+-------------------------------------------------------------------
 Fri Sep 23 15:33:13 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,13 +1,8 @@
 -------------------------------------------------------------------
-Thu Dec 22 09:47:04 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+Thu Dec 29 11:03:00 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - Use ruby base64 to replace uuencode/uudecode
   (bsc#1206601)
-- 4.4.3
-
--------------------------------------------------------------------
-Fri Sep 23 15:33:13 UTC 2022 - Peter Varkoly <varkoly@suse.com>
-
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)
   Enable csync2 by installing the package.
 - 4.4.2

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 23 15:33:13 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)
+  Enable csync2 by installing the package.
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Sep  6 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - YaST2 HA Setup for SAP Products - cannot input several instance numbers

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 
 BuildArch:      noarch

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 
 BuildArch:      noarch

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -99,8 +99,6 @@ install -m 755 data/check_ssh.expect %{buildroot}%{yast_dir}/data/sap_ha/
 install -m 644 data/sapini.aug %{buildroot}%{augeas_dir}
 
 %post
-/usr/bin/systemctl enable csync2.socket
-/usr/bin/systemctl start  csync2.socket
 
 %files
 %defattr(-,root,root)

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 
 BuildArch:      noarch
@@ -27,7 +27,7 @@ Source1:        yast2-sap-ha-rpmlintrc
 
 Requires:       yast2
 Requires:       yast2-ruby-bindings
-Requires:	corosync
+Requires:       corosync
 # for opening URLs
 Requires:       xdg-utils
 # for handling the SSH client
@@ -95,6 +95,10 @@ install -m 644 data/scenarios.yaml %{buildroot}%{yast_dir}/data/sap_ha/
 install -m 755 data/check_ssh.expect %{buildroot}%{yast_dir}/data/sap_ha/
 # Augeas lens for SAP INI files
 install -m 644 data/sapini.aug %{buildroot}%{augeas_dir}
+
+%post
+/usr/bin/systemctl enable csync2.socket
+/usr/bin/systemctl start  csync2.socket
 
 %files
 %defattr(-,root,root)

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.4.3
+Version:        4.4.2
 Release:        0
 
 BuildArch:      noarch

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -28,6 +28,7 @@ Source1:        yast2-sap-ha-rpmlintrc
 Requires:       yast2
 Requires:       yast2-ruby-bindings
 Requires:       corosync
+Requires:       csync2
 # for opening URLs
 Requires:       xdg-utils
 # for handling the SSH client
@@ -47,6 +48,7 @@ Requires:       rubygem(%{rb_default_ruby_abi}:cfa)
 Requires:       sysvinit-tools
 
 BuildRequires:  augeas-lenses
+BuildRequires:  csync2
 BuildRequires:  kmod
 BuildRequires:  sysvinit-tools
 BuildRequires:  update-desktop-files

--- a/src/clients/sap_ha.rb
+++ b/src/clients/sap_ha.rb
@@ -36,7 +36,6 @@ require 'sap_ha/wizard/list_selection'
 require 'sap_ha/wizard/rich_text'
 require 'sap_ha/wizard/scenario_selection_page'
 require 'sap_ha/configuration'
-require 'yast2/systemd/service'
 
 # YaST module
 module Yast
@@ -237,21 +236,16 @@ module Yast
     def main
       textdomain 'hana-ha'
       #Take care that corosync is enabled and running
-      corosync = Yast2::Systemd::Service.find('corosync')
       @sequence["ws_start"] = "debug_run" if @config.debug
       @sequence["product_check"][:hana] = "file_import_check" if @config.imported
       Wizard.CreateDialog
       Wizard.SetDialogTitle("HA Setup for SAP Products")
       begin
-￼       corosync.enable
-￼        corosync.start
         if @config.unattended 
           Sequencer.Run(@aliases, @unattended_sequence) 
         else
           Sequencer.Run(@aliases, @sequence)      
         end
-      rescue NoMethodError => e
-        Popup.Error("corosync service was not found")
       rescue StandardError => e
         # FIXME: y2start overrides the return code, therefore exit prematurely without
         # shutting down Yast properly, see bsc#1099871

--- a/src/lib/sap_ha/semantic_checks.rb
+++ b/src/lib/sap_ha/semantic_checks.rb
@@ -41,6 +41,7 @@ module SapHA
     #The identifier must not be longer than 30 characters and it must be minimum 2 long.
     IDENTIFIER_REGEXP = Regexp.new('^[a-zA-Z0-9][a-zA-Z0-9_\-]{1,29}$')
     SAP_SID_REGEXP = Regexp.new('^[A-Z][A-Z0-9]{2}$')
+    SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')
     RESERVED_SAP_SIDS = %w(ADD ALL AND ANY ASC COM DBA END EPS FOR GID IBM INT KEY LOG MON NIX
                            NOT OFF OMS RAW ROW SAP SET SGA SHG SID SQL SYS TMP UID USR VAR).freeze
 
@@ -247,10 +248,10 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def sap_instance_number(value, message, field_name)
-      return report_error(false, 'The SAP Instance number must be a string of exactly two digits',
-        field_name, value) unless value.is_a?(::String) && value.length == 2
-      integer_in_range(value, 0, 99, message, field_name)
+    def sap_instance_number(value, message = '', field_name = 'Instant Number')
+      message = "The SAP Instance number must be a string of exactly two digits " if message.nil? || message.empty?
+      flag = SAP_INST_NUM_REGEX.match?(value)
+      report_error(flag, message, field_name, value)
     end
 
     # Check if the provided value is a non-empty string

--- a/src/lib/sap_ha/system/local.rb
+++ b/src/lib/sap_ha/system/local.rb
@@ -224,10 +224,11 @@ module SapHA
         success = true
         success &= systemd_unit(:enable, :service, 'sbd')
         success &= systemd_unit(:enable, :socket, 'csync2')
+        success &= systemd_unit(:start,  :socket, 'csync2')
         success &= systemd_unit(:enable, :service, 'pacemaker')
-        success &= systemd_unit(:start, :service, 'pacemaker')
+        success &= systemd_unit(:start,  :service, 'pacemaker')
         success &= systemd_unit(:enable, :service, 'hawk')
-        success &= systemd_unit(:start, :service, 'hawk')
+        success &= systemd_unit(:start,  :service, 'hawk')
         NodeLogger.log_status(
           success,
           'Enabled and started cluster-required systemd units',

--- a/src/lib/sap_ha/system/local.rb
+++ b/src/lib/sap_ha/system/local.rb
@@ -150,8 +150,8 @@ module SapHA
         begin
           File.write(CSYNC2_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared csync2 authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared csync2 authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared csync2 authentication key. Error: #{error}")
         end
       end
 
@@ -181,8 +181,8 @@ module SapHA
         begin
           File.write(COROSYNC_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared corosync secure authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared corosync secure authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared corosync secure authentication key. Error: #{error}")
         end
       end
 

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -138,5 +138,17 @@ describe SapHA::SemanticChecks do
       expect(subject.ipv4_in_network_cidr('192.168.100.14', '192.168.100.0/28')).to eq true
       expect(subject.ipv4_in_network_cidr('192.168.100.16', '192.168.100.0/28')).to eq false
     end
+    it 'reports if valid instance number will be allowed' do
+      subject.silent = true
+      expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('10')).to eq true
+      expect(subject.sap_instance_number('99')).to eq true
+    end
+    it 'reports if invalid instance number will be found' do
+      subject.silent = true
+      expect(subject.sap_instance_number('1')).to eq false
+      expect(subject.sap_instance_number('1A')).to eq false
+      expect(subject.sap_instance_number('999')).to eq false
+    end
   end
 end

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -141,6 +141,7 @@ describe SapHA::SemanticChecks do
     it 'reports if valid instance number will be allowed' do
       subject.silent = true
       expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('09')).to eq true
       expect(subject.sap_instance_number('10')).to eq true
       expect(subject.sap_instance_number('99')).to eq true
     end


### PR DESCRIPTION
## Problem
Valid SAP instance number is not recognized as valid.
- https://bugzilla.suse.com/show_bug.cgi?id=1202979
The SAP instance number must contains 2 digits and it is in the range from 00 to 99.
Integer numbers starting with 0 are interpreted by Ruby as octal numbers. Therefore 08 and 09 are not recognized as valid.

csync2.socket is not enabled
- https://bugzilla.suse.com/show_bug.cgi?id=1202112

## Solution

Use a regex to validate the SAP instance number:

SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')

Enable and start csync2.socket during installation of the package.