### PR TITLE
YaST2 HA Setup for SAP Products - cannot input several instance numbe…

### DIFF
--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  6 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- YaST2 HA Setup for SAP Products - cannot input several instance numbers
+  (bsc#1202979)
+- 1.0.16
+
+-------------------------------------------------------------------
 Mon Jun 13 14:32:45 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - YaST2 sap_ha tool does not allow digits at the beginning of site names

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        1.0.15
+Version:        1.0.16
 Release:        0
 
 BuildArch:      noarch

--- a/src/lib/sap_ha/semantic_checks.rb
+++ b/src/lib/sap_ha/semantic_checks.rb
@@ -41,6 +41,7 @@ module SapHA
     #The identifier must not be longer than 30 characters and it must be minimum 2 long.
     IDENTIFIER_REGEXP = Regexp.new('^[a-zA-Z0-9][a-zA-Z0-9_\-]{1,29}$')
     SAP_SID_REGEXP = Regexp.new('^[A-Z][A-Z0-9]{2}$')
+    SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')
     RESERVED_SAP_SIDS = %w(ADD ALL AND ANY ASC COM DBA END EPS FOR GID IBM INT KEY LOG MON NIX
                            NOT OFF OMS RAW ROW SAP SET SGA SHG SID SQL SYS TMP UID USR VAR).freeze
 
@@ -247,10 +248,10 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def sap_instance_number(value, message, field_name)
-      return report_error(false, 'The SAP Instance number must be a string of exactly two digits',
-        field_name, value) unless value.is_a?(::String) && value.length == 2
-      integer_in_range(value, 0, 99, message, field_name)
+    def sap_instance_number(value, message = '', field_name = 'Instant Number')
+      message = "The SAP Instance number must be a string of exactly two digits " if message.nil? || message.empty?
+      flag = SAP_INST_NUM_REGEX.match?(value)
+      report_error(flag, message, field_name, value)
     end
 
     # Check if the provided value is a non-empty string

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -158,5 +158,17 @@ describe SapHA::SemanticChecks do
       expect(subject.sap_sid('123')).to eq false
       expect(subject.sap_sid('NOT')).to eq false
     end
+    it 'reports if valid instance number will be allowed' do
+      subject.silent = true
+      expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('10')).to eq true
+      expect(subject.sap_instance_number('99')).to eq true
+    end
+    it 'reports if invalid instance number will be found' do
+      subject.silent = true
+      expect(subject.sap_instance_number('1')).to eq false
+      expect(subject.sap_instance_number('1A')).to eq false
+      expect(subject.sap_instance_number('999')).to eq false
+    end
   end
 end

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -160,7 +160,8 @@ describe SapHA::SemanticChecks do
     end
     it 'reports if valid instance number will be allowed' do
       subject.silent = true
-      expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('05')).to eq true
+      expect(subject.sap_instance_number('09')).to eq true
       expect(subject.sap_instance_number('10')).to eq true
       expect(subject.sap_instance_number('99')).to eq true
     end


### PR DESCRIPTION
## Problem
Valid SAP instance number is not recognized as valid.
- https://bugzilla.suse.com/show_bug.cgi?id=1202979
The SAP instance number must contains 2 digits and it is in the range from 00 to 99.
Integer numbers starting with 0 are interpreted by Ruby as octal numbers. Therefore 08 and 09 are not recognized as valid.

## Solution

Use a regex to validate the SAP instance number:

SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')
