### PR TITLE
Fix validating SAP instance number

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,17 +18,7 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  conf.skip_license_check << /.*desktop$/
-  conf.skip_license_check << /.*erb$/
-  conf.skip_license_check << /.*yaml$/
-  conf.skip_license_check << /.*yml$/
-  conf.skip_license_check << /.*html$/
-  conf.skip_license_check << /.*rpmlintrc$/
-  conf.skip_license_check << /pry_debug.rb/
-  conf.skip_license_check << /make_package.sh/
-  conf.skip_license_check << /srhook.py.tmpl/
-  conf.skip_license_check << /collect_logs.sh/
-  conf.skip_license_check << /aux/
+  conf.skip_license_check << /.*/
   conf.exclude_files << /pry_debug.rb/
   conf.exclude_files << /.rubocop.yml/
   conf.exclude_files << /TODO.md/
@@ -38,18 +28,3 @@ Yast::Tasks.configuration do |conf|
   conf.exclude_files << /aux/
 end
 
-desc "Run unit tests with coverage."
-task "coverage" do
-  files = Dir["**/test/**/*_{spec,test}.rb"]
-  sh "export COVERAGE=1; rspec --color --format doc '#{files.join("' '")}'" unless files.empty?
-end
-
-Rake::Task["check:committed"].clear
-
-# namespace :test do
-#   desc "Runs unit tests."
-#   task "unit" do
-#     files = Dir["**/test/**/*_{spec,test}.rb"]
-#     sh "rspec --color --format doc '#{files.join("' '")}'" unless files.empty?
-#   end
-# end

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep  6 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- YaST2 HA Setup for SAP Products - cannot input several instance numbers
+  (bsc#1202979)
+- 4.5.3
+
+-------------------------------------------------------------------
 Tue Aug  9 08:16:47 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 22 09:47:04 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- Use ruby base64 to replace uuencode/uudecode
+  (bsc#1206601)
+- 4.5.6
+
+-------------------------------------------------------------------
 Fri Sep 23 15:18:58 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,13 +1,9 @@
 -------------------------------------------------------------------
-Thu Dec 22 09:47:04 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+Thu Dec 29 11:09:12 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
+- Clean up Rakefile
 - Use ruby base64 to replace uuencode/uudecode
   (bsc#1206601)
-- 4.5.6
-
--------------------------------------------------------------------
-Fri Sep 23 15:18:58 UTC 2022 - Peter Varkoly <varkoly@suse.com>
-
 - yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)
   Enable csync2 by installing the package. yast2-sap-ha will
   not be executed on the second node.

--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Sep 23 15:18:58 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- yast2-sap-ha: csync2 configuration not enabled (bsc#1202112)
+  Enable csync2 by installing the package. yast2-sap-ha will
+  not be executed on the second node.
+- 4.5.5
+
+-------------------------------------------------------------------
 Tue Sep  9 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - YaST2 HA Setup for SAP Products - cannot input several instance numbers

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 
 BuildArch:      noarch
@@ -27,7 +27,8 @@ Source1:        yast2-sap-ha-rpmlintrc
 
 Requires:       yast2
 Requires:       yast2-ruby-bindings
-Requires:	corosync
+Requires:       csync2
+Requires:       corosync
 # for opening URLs
 Requires:       xdg-utils
 # for handling the SSH client
@@ -99,6 +100,10 @@ install -m 644 data/scenarios.yaml %{buildroot}%{yast_dir}/data/sap_ha/
 install -m 755 data/check_ssh.expect %{buildroot}%{yast_dir}/data/sap_ha/
 # Augeas lens for SAP INI files
 install -m 644 data/sapini.aug %{buildroot}%{augeas_dir}
+
+%post
+/usr/bin/systemctl enable csync2.socket
+/usr/bin/systemctl start  csync2.socket
 
 %files
 %defattr(-,root,root)

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 
 BuildArch:      noarch

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.5.2
+Version:        4.5.3
 Release:        0
 
 BuildArch:      noarch

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.5.6
+Version:        4.5.5
 Release:        0
 
 BuildArch:      noarch

--- a/src/clients/sap_ha.rb
+++ b/src/clients/sap_ha.rb
@@ -19,24 +19,24 @@
 # Summary: SUSE High Availability Setup for SAP Products: main GUI Wizard class
 # Authors: Ilya Manyugin <ilya.manyugin@suse.com>
 
-require 'yast'
-require 'psych'
-require 'sap_ha/helpers'
-require 'sap_ha/node_logger'
-require 'sap_ha/wizard/cluster_nodes_page'
-require 'sap_ha/wizard/comm_layer_page'
-require 'sap_ha/wizard/join_cluster_page'
-require 'sap_ha/wizard/fencing_page'
-require 'sap_ha/wizard/watchdog_page'
-require 'sap_ha/wizard/hana_page'
-require 'sap_ha/wizard/ntp_page'
-require 'sap_ha/wizard/overview_page'
-require 'sap_ha/wizard/summary_page'
-require 'sap_ha/wizard/gui_installation_page'
-require 'sap_ha/wizard/list_selection'
-require 'sap_ha/wizard/rich_text'
-require 'sap_ha/wizard/scenario_selection_page'
-require 'sap_ha/configuration'
+require "yast"
+require "psych"
+require "sap_ha/helpers"
+require "sap_ha/node_logger"
+require "sap_ha/wizard/cluster_nodes_page"
+require "sap_ha/wizard/comm_layer_page"
+require "sap_ha/wizard/join_cluster_page"
+require "sap_ha/wizard/fencing_page"
+require "sap_ha/wizard/watchdog_page"
+require "sap_ha/wizard/hana_page"
+require "sap_ha/wizard/ntp_page"
+require "sap_ha/wizard/overview_page"
+require "sap_ha/wizard/summary_page"
+require "sap_ha/wizard/gui_installation_page"
+require "sap_ha/wizard/list_selection"
+require "sap_ha/wizard/rich_text"
+require "sap_ha/wizard/scenario_selection_page"
+require "sap_ha/configuration"
 
 # YaST module
 module Yast
@@ -44,10 +44,10 @@ module Yast
   class SAPHAClass < Client
     attr_reader :sequence
 
-    Yast.import 'UI'
-    Yast.import 'Wizard'
-    Yast.import 'Sequencer'
-    Yast.import 'Popup'
+    Yast.import "UI"
+    Yast.import "Wizard"
+    Yast.import "Sequencer"
+    Yast.import "Popup"
     include Yast::UIShortcuts
     include Yast::Logger
     include SapHA::Exceptions
@@ -55,15 +55,15 @@ module Yast
     def initialize
       log.warn "--- called #{self.class}.#{__callee__}: CLI arguments are #{WFM.Args} ---"
       begin 
-        if WFM.Args.include?('readconfig')
-          ix = WFM.Args.index('readconfig') + 1
-	  begin
+        if WFM.Args.include?("readconfig")
+          ix = WFM.Args.index("readconfig") + 1
+          begin
             @config = Psych.unsafe_load(File.read(WFM.Args[ix]))
-	  rescue NoMethodError
+          rescue NoMethodError
             @config = Psych.load(File.read(WFM.Args[ix]))
-	  end
+          end
           @config.imported = true
-          if WFM.Args.include?('unattended')
+          if WFM.Args.include?("unattended")
             @config.unattended = true
           end  
         else
@@ -78,9 +78,9 @@ module Yast
         @config = SapHA::HAConfiguration.new
         Popup.TimedError("The configuration file could not be loaded because of a unexpected error. Switching to the manual configuration. Details: #{e.message}", 10)
       ensure
-        @config.debug = WFM.Args.include? 'over'
-        @config.no_validators = WFM.Args.include?('noval') || WFM.Args.include?('validators')
-        Wizard.SetTitleIcon('yast-heartbeat')
+        @config.debug = WFM.Args.include? "over"
+        @config.no_validators = WFM.Args.include?("noval") || WFM.Args.include?("validators")
+        Wizard.SetTitleIcon("yast-heartbeat")
         @sequence = {
           "ws_start"              => "product_check",
           "product_check"         =>  {
@@ -216,30 +216,30 @@ module Yast
 
 
         @aliases = {
-          'product_check'         => -> { product_check },
-          'file_import_check'    => -> { file_import_check },
-          'scenario_selection'    => -> { scenario_selection },
-          'product_not_supported' => -> { product_not_supported },
-          # 'prereqs_notice'        => [-> () { show_prerequisites }, true],
-          'prereqs_notice'        => -> { show_prerequisites },
-          'configure_cluster'     => -> { configure_cluster },
-          'configure_comm_layer'  => -> { configure_comm_layer },
-          'join_cluster'          => -> { join_existing_cluster },
-          'fencing'               => -> { fencing_mechanism },
-          'watchdog'              => -> { watchdog },
-          'hana'                  => -> { configure_hana },
-          'debug_run'             => -> { debug_run },
-          'installation'          => -> { run_installation },
-          'unattended_install'    => -> { run_unattended_install },
-          'ntp'                   => -> { configure_ntp },
-          'config_overview'       => -> { configuration_overview },
-          'summary'               => -> { show_summary }
+          "product_check"         => -> { product_check },
+          "file_import_check"    => -> { file_import_check },
+          "scenario_selection"    => -> { scenario_selection },
+          "product_not_supported" => -> { product_not_supported },
+          # "prereqs_notice"        => [-> () { show_prerequisites }, true],
+          "prereqs_notice"        => -> { show_prerequisites },
+          "configure_cluster"     => -> { configure_cluster },
+          "configure_comm_layer"  => -> { configure_comm_layer },
+          "join_cluster"          => -> { join_existing_cluster },
+          "fencing"               => -> { fencing_mechanism },
+          "watchdog"              => -> { watchdog },
+          "hana"                  => -> { configure_hana },
+          "debug_run"             => -> { debug_run },
+          "installation"          => -> { run_installation },
+          "unattended_install"    => -> { run_unattended_install },
+          "ntp"                   => -> { configure_ntp },
+          "config_overview"       => -> { configuration_overview },
+          "summary"               => -> { show_summary }
         }
       end  
     end
 
     def main
-      textdomain 'hana-ha'
+      textdomain "hana-ha"
       @sequence["ws_start"] = "debug_run" if @config.debug
       @sequence["product_check"][:hana] = "file_import_check" if @config.imported
       Wizard.CreateDialog
@@ -278,9 +278,9 @@ module Yast
     def product_check
       log.debug "--- called #{self.class}.#{__callee__} ---"
       # TODO: here we need to know what product we are installing
-      # Yast.import 'SAPProduct'
+      # Yast.import "SAPProduct"
       # SAPProduct.Read
-      # SAPProduct.installedProducts [{productID: 'HANA'...}...]
+      # SAPProduct.installedProducts [{productID: "HANA"...}...]
       begin
         @config.set_product_id "HANA"
       rescue ProductNotFoundException => e
@@ -290,7 +290,7 @@ module Yast
       # TODO: here we should check if the symbol can be handled by th
         #stat = Yast::Cluster.LoadClusterConfig
         #Yast::Cluster.load_csync2_confe Sequencer
-      @config.product.fetch('id', 'abort').downcase.to_sym
+      @config.product.fetch("id", "abort").downcase.to_sym
     end
 
     def file_import_check
@@ -323,9 +323,9 @@ module Yast
     def product_not_supported
       log.debug "--- called #{self.class}.#{__callee__} ---"
       SapHA::Wizard::RichText.new.run(
-        'Product not supported',
-        SapHA::Helpers.load_help('product_not_found'),
-        SapHA::Helpers.load_help('product_not_found'),
+        "Product not supported",
+        SapHA::Helpers.load_help("product_not_found"),
+        SapHA::Helpers.load_help("product_not_found"),
         false,
         false
       )
@@ -335,12 +335,12 @@ module Yast
 
     def show_prerequisites
       log.error "--- called #{self.class}.#{__callee__} ---"
-      notice = @config.scenario['prerequisites_notice']
+      notice = @config.scenario["prerequisites_notice"]
       return :next unless notice
       SapHA::Wizard::RichText.new.run(
-        'Prerequisites',
+        "Prerequisites",
         SapHA::Helpers.load_help(notice, @config.platform),
-        '',
+        "",
         true,
         true
       )
@@ -350,7 +350,7 @@ module Yast
       log.debug "--- called #{self.class}.#{__callee__} ---"
       log.error("No HA scenarios found for product #{@product_name}")
       SapHA::Wizard::RichText.new.run(
-        'Scenarios not found',
+        "Scenarios not found",
         "There were no HA scenarios found for the product #{@product_name}",
         "The product you are installing is not supported by this module.<br>
         You can set up a cluster manually using the Cluster YaST module.",
@@ -402,7 +402,7 @@ module Yast
 
     def run_installation
       log.debug "--- called #{self.class}.#{__callee__} ---"
-      return :next if WFM.Args.include? 'noinst'
+      return :next if WFM.Args.include? "noinst"
       ui = SapHA::Wizard::GUIInstallationPage.new
       begin
         SapHA::SAPHAInstallation.new(@config, ui).run
@@ -417,7 +417,7 @@ module Yast
 
     def run_unattended_install
       log.debug "--- called #{self.class}.#{__callee__} ---"
-      return :next if WFM.Args.include? 'noinst'
+      return :next if WFM.Args.include? "noinst"
       ui = SapHA::Wizard::GUIInstallationPage.new
       begin
         # FIXME: We cannot use the unattended install as the other YaST Modules need
@@ -441,10 +441,10 @@ module Yast
 
     def debug_run
       @config.set_product_id "HANA"
-      if WFM.Args.include? 'cost'
-        @config.set_scenario_name 'Scale Up: Cost-optimized'
+      if WFM.Args.include? "cost"
+        @config.set_scenario_name "Scale Up: Cost-optimized"
       else
-        @config.set_scenario_name 'Scale Up: Performance-optimized'
+        @config.set_scenario_name "Scale Up: Performance-optimized"
       end
       :config_overview
     end

--- a/src/clients/sap_ha.rb
+++ b/src/clients/sap_ha.rb
@@ -241,15 +241,11 @@ module Yast
 
     def main
       textdomain 'hana-ha'
-      #Take care that corosync is enabled and running
-      corosync = Yast2::Systemd::Service.find('corosync')
       @sequence["ws_start"] = "debug_run" if @config.debug
       @sequence["product_check"][:hana] = "file_import_check" if @config.imported
       Wizard.CreateDialog
       Wizard.SetDialogTitle("HA Setup for SAP Products")
       begin
-        corosync.enable
-        corosync.start
         if @config.unattended 
           Sequencer.Run(@aliases, @unattended_sequence) 
         else

--- a/src/clients/sap_ha.rb
+++ b/src/clients/sap_ha.rb
@@ -37,7 +37,6 @@ require 'sap_ha/wizard/list_selection'
 require 'sap_ha/wizard/rich_text'
 require 'sap_ha/wizard/scenario_selection_page'
 require 'sap_ha/configuration'
-require 'yast2/systemd/service'
 
 # YaST module
 module Yast
@@ -250,10 +249,6 @@ module Yast
           Sequencer.Run(@aliases, @unattended_sequence) 
         else
           Sequencer.Run(@aliases, @sequence)      
-        end
-      rescue NoMethodError => e
-        if corosync.nil?
-          Popup.Error("corosync service was not found")
         end
       rescue StandardError => e
         # FIXME: y2start overrides the return code, therefore exit prematurely without

--- a/src/lib/sap_ha/semantic_checks.rb
+++ b/src/lib/sap_ha/semantic_checks.rb
@@ -19,12 +19,12 @@
 # Summary: SUSE High Availability Setup for SAP Products: Input validators and checks
 # Authors: Ilya Manyugin <ilya.manyugin@suse.com>
 
-require 'sap_ha/exceptions'
-require 'yast'
-require 'erb'
+require "sap_ha/exceptions"
+require "yast"
+require "erb"
 
-Yast.import 'IP'
-Yast.import 'Hostname'
+Yast.import "IP"
+Yast.import "Hostname"
 
 module SapHA
   # Input validators and checks
@@ -39,9 +39,9 @@ module SapHA
     #expect of '*' and '/'. The identifier can be 256 character long
     #However, for security and technical reasons, we only allow alphanumeric characters as well as '-' and '_'.
     #The identifier must not be longer than 30 characters and it must be minimum 2 long.
-    IDENTIFIER_REGEXP = Regexp.new('^[a-zA-Z0-9][a-zA-Z0-9_\-]{1,29}$')
-    SAP_SID_REGEXP = Regexp.new('^[A-Z][A-Z0-9]{2}$')
-    SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')
+    IDENTIFIER_REGEXP = Regexp.new("^[a-zA-Z0-9][a-zA-Z0-9_\-]{1,29}$")
+    SAP_SID_REGEXP = Regexp.new("^[A-Z][A-Z0-9]{2}$")
+    SAP_INST_NUM_REGEX = Regexp.new("^[0-9]{2}$")
     RESERVED_SAP_SIDS = %w(ADD ALL AND ANY ASC COM DBA END EPS FOR GID IBM INT KEY LOG MON NIX
                            NOT OFF OMS RAW ROW SAP SET SGA SHG SID SQL SYS TMP UID USR VAR).freeze
 
@@ -55,7 +55,7 @@ module SapHA
     # Check if the string is a valid IPv4 address
     # @param value [String] IP address
     # @param field_name [String] name of the field in the form
-    def ipv4(value, field_name = '')
+    def ipv4(value, field_name = "")
       flag = Yast::IP.Check4(value)
       report_error(flag, Yast::IP.Valid4, field_name, value)
     end
@@ -63,18 +63,18 @@ module SapHA
     # Check if the string is a valid IPv4 netmask
     # @param value [String] network mask
     # @param field_name [String] name of the field in the form
-    def ipv4_netmask(value, field_name = '')
+    def ipv4_netmask(value, field_name = "")
       flag = Yast::Netmask.Check4(value)
-      report_error(flag, 'A valid network mask consists of 4 octets separated by dots.',
+      report_error(flag, "A valid network mask consists of 4 octets separated by dots.",
         field_name, value)
     end
 
     # Check if the string is a valid IPv4 multicast address
     # @param value [String] IP address
     # @param field_name [String] name of the field in the form
-    def ipv4_multicast(value, field_name = '')
-      flag = Yast::IP.Check4(value) && value.start_with?('239.')
-      msg = 'A valid IPv4 multicast address should belong to the 239.* network.'
+    def ipv4_multicast(value, field_name = "")
+      flag = Yast::IP.Check4(value) && value.start_with?("239.")
+      msg = "A valid IPv4 multicast address should belong to the 239.* network."
       report_error(flag, msg, field_name, value)
     end
 
@@ -82,7 +82,7 @@ module SapHA
     # @param ip [String] IP address
     # @param network [String] IP address
     # @param field_name [String] name of the field in the form
-    def ipv4_in_network_cidr(ip, network, field_name = '')
+    def ipv4_in_network_cidr(ip, network, field_name = "")
       begin
         flag = IPAddr.new(network).include?(ip)
       rescue StandardError
@@ -97,7 +97,7 @@ module SapHA
     # @param network [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def ipsv4_in_network_cidr(ips, network, message = '', field_name = '')
+    def ipsv4_in_network_cidr(ips, network, message = "", field_name = "")
       message = "IP addresses have to belong to the network #{network}" \
         if message.nil? || message.empty?
       begin
@@ -106,13 +106,13 @@ module SapHA
         return
       end
       flag = ips.map { |ip| net.include?(ip) }.all?
-      report_error(flag, message, field_name, '')
+      report_error(flag, message, field_name, "")
     end
 
     # Check if the provided value is a valid hostname
     # @param value [String] hostname to check
     # @param field_name [String] name of the field in the form
-    def hostname(value, field_name = '')
+    def hostname(value, field_name = "")
       flag = Yast::Hostname.Check(value)
       report_error(flag, Yast::Hostname.ValidHost, field_name, value)
     end
@@ -120,7 +120,7 @@ module SapHA
     # Check if the provided value is a valid port number
     # @param value [String] port number to check
     # @param field_name [String] name of the field in the form
-    def port(value, field_name = '')
+    def port(value, field_name = "")
       max_port_number = 65_535
       msg = "The port number must be in between 1 and #{max_port_number}."
       begin
@@ -135,7 +135,7 @@ module SapHA
     # Check if the provided value is a non-negative integer
     # @param value [Integer] value to check
     # @param field_name [String] name of the field in the form
-    def nonneg_integer(value, field_name = '')
+    def nonneg_integer(value, field_name = "")
       flag = true
       begin
         int_ = Integer(value)
@@ -143,7 +143,7 @@ module SapHA
       rescue ArgumentError
         flag = false
       end
-      report_error(flag, 'The value must be a non-negative integer.', field_name, value)
+      report_error(flag, "The value must be a non-negative integer.", field_name, value)
     end
 
     # Check if the element belongs to the set
@@ -151,7 +151,7 @@ module SapHA
     # @param set [Array[Any]]
     # @param message [String] custom error message
     # @param field_name [String] name of the field in the form
-    def element_in_set(element, set, message = '', field_name = '')
+    def element_in_set(element, set, message = "", field_name = "")
       flag = set.include? element
       message = "The value must be in the set [#{set.join(', ')}]" if message.nil? || message.empty?
       report_error(flag, message, field_name, element)
@@ -162,9 +162,9 @@ module SapHA
     # @param set2 [Array]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def intersection_not_empty(set1, set2, message = '', field_name = '')
+    def intersection_not_empty(set1, set2, message = "", field_name = "")
       flag = !(set1 & set2).empty?
-      report_error(flag, message, field_name, '')
+      report_error(flag, message, field_name, "")
     end
 
     # Check if the values match
@@ -172,7 +172,7 @@ module SapHA
     # @param lvalue [Any]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def equal(rvalue, lvalue, message = '', field_name = '')
+    def equal(rvalue, lvalue, message = "", field_name = "")
       eq = rvalue == lvalue
       report_error(eq, message, field_name, nil)
     end
@@ -182,7 +182,7 @@ module SapHA
     # @param lvalue [Any]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def not_equal(rvalue, lvalue, message = '', field_name = '')
+    def not_equal(rvalue, lvalue, message = "", field_name = "")
       neq = rvalue != lvalue
       report_error(neq, message, field_name, nil)
     end
@@ -191,7 +191,7 @@ module SapHA
     # @param set [Array]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def unique(set, message = '', field_name = '')
+    def unique(set, message = "", field_name = "")
       uniq = (set == (set & set))
       report_error(uniq, message, field_name, nil)
     end
@@ -200,7 +200,7 @@ module SapHA
     # @param set [Array]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def not_unique(set, message = '', field_name = '')
+    def not_unique(set, message = "", field_name = "")
       uniq = (set != (set & set))
       report_error(uniq, message, field_name, nil)
     end
@@ -209,9 +209,9 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def identifier(value, message = '', field_name = '')
+    def identifier(value, message = "", field_name = "")
       flag = !IDENTIFIER_REGEXP.match(value).nil?
-      message = 'The value should be a valid identifier' if message.nil? || message.empty?
+      message = "The value should be a valid identifier" if message.nil? || message.empty?
       report_error(flag, message, field_name, value)
     end
 
@@ -221,7 +221,7 @@ module SapHA
     # @param high [Integer]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def integer_in_range(value, low, high, message = '', field_name = '')
+    def integer_in_range(value, low, high, message = "", field_name = "")
       message = "The value must be in the range between #{low} and #{high}." \
         if message.nil? || message.empty?
       begin
@@ -237,7 +237,7 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def sap_sid(value, message = '', field_name = '')
+    def sap_sid(value, message = "", field_name = "")
       message = "A valid SAP System ID consists of three characters, starts with a letter, and "\
       " must not collide with one of the reserved IDs" if message.nil? || message.empty?
       flag = !SAP_SID_REGEXP.match(value).nil? && !RESERVED_SAP_SIDS.include?(value)
@@ -248,8 +248,8 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def sap_instance_number(value, message = '', field_name = 'Instant Number')
-      message = "The SAP Instance number must be a string of exactly two digits " if message.nil? || message.empty?
+    def sap_instance_number(value, message = "", field_name = "Instant Number")
+      message = "The SAP Instance number must be a string of exactly two digits" if message.nil? || message.empty?
       flag = SAP_INST_NUM_REGEX.match?(value)
       report_error(flag, message, field_name, value)
     end
@@ -260,7 +260,7 @@ module SapHA
     # @param field_name [String] name of the related field in the form
     def non_empty_string(value, message, field_name, hide_value = false)
       flag = value.is_a?(::String) && !value.empty?
-      shown_value = hide_value ? '' : value
+      shown_value = hide_value ? "" : value
       report_error(flag, message || "The value must be a non-empty string", field_name, shown_value)
     end
 
@@ -340,7 +340,7 @@ module SapHA
     def error_string(field_name, explanation, value = nil)
       field_name = field_name.strip
       explanation = explanation.strip
-      explanation = explanation[0..-2] if explanation.end_with? '.'
+      explanation = explanation[0..-2] if explanation.end_with? "."
       explanation = explanation
       if field_name.empty?
         "Invalid input: #{explanation}"

--- a/src/lib/sap_ha/semantic_checks.rb
+++ b/src/lib/sap_ha/semantic_checks.rb
@@ -41,6 +41,7 @@ module SapHA
     #The identifier must not be longer than 30 characters and it must be minimum 2 long.
     IDENTIFIER_REGEXP = Regexp.new('^[a-zA-Z0-9][a-zA-Z0-9_\-]{1,29}$')
     SAP_SID_REGEXP = Regexp.new('^[A-Z][A-Z0-9]{2}$')
+    SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')
     RESERVED_SAP_SIDS = %w(ADD ALL AND ANY ASC COM DBA END EPS FOR GID IBM INT KEY LOG MON NIX
                            NOT OFF OMS RAW ROW SAP SET SGA SHG SID SQL SYS TMP UID USR VAR).freeze
 
@@ -247,10 +248,10 @@ module SapHA
     # @param value [String]
     # @param message [String] custom error message
     # @param field_name [String] name of the related field in the form
-    def sap_instance_number(value, message, field_name)
-      return report_error(false, 'The SAP Instance number must be a string of exactly two digits',
-        field_name, value) unless value.is_a?(::String) && value.length == 2
-      integer_in_range(value, 0, 99, message, field_name)
+    def sap_instance_number(value, message = '', field_name = 'Instant Number')
+      message = "The SAP Instance number must be a string of exactly two digits " if message.nil? || message.empty?
+      flag = SAP_INST_NUM_REGEX.match?(value)
+      report_error(flag, message, field_name, value)
     end
 
     # Check if the provided value is a non-empty string

--- a/src/lib/sap_ha/system/local.rb
+++ b/src/lib/sap_ha/system/local.rb
@@ -224,10 +224,11 @@ module SapHA
         success = true
         success &= systemd_unit(:enable, :service, 'sbd')
         success &= systemd_unit(:enable, :socket, 'csync2')
+        success &= systemd_unit(:start,  :socket, 'csync2')
         success &= systemd_unit(:enable, :service, 'pacemaker')
-        success &= systemd_unit(:start, :service, 'pacemaker')
+        success &= systemd_unit(:start,  :service, 'pacemaker')
         success &= systemd_unit(:enable, :service, 'hawk')
-        success &= systemd_unit(:start, :service, 'hawk')
+        success &= systemd_unit(:start,  :service, 'hawk')
         NodeLogger.log_status(
           success,
           'Enabled and started cluster-required systemd units',

--- a/src/lib/sap_ha/system/local.rb
+++ b/src/lib/sap_ha/system/local.rb
@@ -150,8 +150,8 @@ module SapHA
         begin
           File.write(CSYNC2_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared csync2 authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared csync2 authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared csync2 authentication key. Error: #{error}")
         end
       end
 
@@ -181,8 +181,8 @@ module SapHA
         begin
           File.write(COROSYNC_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared corosync secure authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared corosync secure authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared corosync secure authentication key. Error: #{error}")
         end
       end
 

--- a/src/lib/sap_ha/system/watchdog.rb
+++ b/src/lib/sap_ha/system/watchdog.rb
@@ -112,8 +112,7 @@ module SapHA
           log.error "Could not find the kernel modules source directory #{MODULES_PATH}"
           return []
         end
-        wmods = Dir.glob(MODULES_PATH + '/*.ko*').map { |path| File.basename(path).gsub(/\.ko[\.\S+]*$/,'') }
-        wmods
+        Dir.glob(MODULES_PATH + '/*.ko*').map { |path| File.basename(path).gsub(/\.ko[\.\S+]*$/,'') }
       end
 
       # Look into the /etc/modules-load.d and list all of the modules

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -158,5 +158,17 @@ describe SapHA::SemanticChecks do
       expect(subject.sap_sid('123')).to eq false
       expect(subject.sap_sid('NOT')).to eq false
     end
+    it 'reports if valid instance number will be allowed' do
+      subject.silent = true
+      expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('10')).to eq true
+      expect(subject.sap_instance_number('99')).to eq true
+    end
+    it 'reports if invalid instance number will be found' do
+      subject.silent = true
+      expect(subject.sap_instance_number('1')).to eq false
+      expect(subject.sap_instance_number('1A')).to eq false
+      expect(subject.sap_instance_number('999')).to eq false
+    end
   end
 end

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -24,152 +24,168 @@ require 'sap_ha/semantic_checks'
 describe SapHA::SemanticChecks do
   subject { SapHA::SemanticChecks.instance }
 
-  describe '#ipv4' do
-    it "reports validness of an IP address in silent mode" do
-      subject.silent = true
-      expect(subject.ipv4('100')).to eq false
-      expect(subject.ipv4('')).to eq false
-      expect(subject.ipv4(1000)).to eq false
-      expect(subject.ipv4(nil)).to eq false
-      expect(subject.ipv4('192.168.100.100')).to eq true
+  context 'SAP network configuration tests' do
+    describe '#ipv4' do
+      it "reports validness of an IP address in silent mode" do
+        subject.silent = true
+        expect(subject.ipv4('100')).to eq false
+        expect(subject.ipv4('')).to eq false
+        expect(subject.ipv4(1000)).to eq false
+        expect(subject.ipv4(nil)).to eq false
+        expect(subject.ipv4('192.168.100.100')).to eq true
+      end
+
+      it "reports validness of an IP address in verbose mode" do
+        subject.silent = false
+        expect(subject.ipv4('100')).to be_kind_of ::String
+        expect(subject.ipv4('')).to be_kind_of ::String
+        expect(subject.ipv4(1000)).to be_kind_of ::String
+        expect(subject.ipv4(nil)).to be_kind_of ::String
+        expect(subject.ipv4('192.168.100.100')).to eq nil
+      end
+
+      it "works in a transaction" do
+        flag = subject.silent_check do |check|
+          check.ipv4('100')
+          check.ipv4('192.168.100.100')
+        end
+
+        expect(flag).to eq false
+
+        flag = subject.silent_check do |check|
+          check.ipv4('192.168.100.100')
+          check.ipv4('192.168.100.1')
+        end
+
+        expect(flag).to eq true
+        errs = subject.verbose_check do |check|
+          check.ipv4('192.168.100.100')
+          check.ipv4('192.168.100.1')
+        end
+
+        expect(errs).to be_empty
+        errs = subject.verbose_check do |check|
+          check.ipv4('10')
+          check.ipv4('102.100.100.100')
+        end
+        expect(errs).not_to be_empty
+      end
     end
 
-    it "reports validness of an IP address in verbose mode" do
-      subject.silent = false
-      expect(subject.ipv4('100')).to be_kind_of ::String
-      expect(subject.ipv4('')).to be_kind_of ::String
-      expect(subject.ipv4(1000)).to be_kind_of ::String
-      expect(subject.ipv4(nil)).to be_kind_of ::String
-      expect(subject.ipv4('192.168.100.100')).to eq nil
+    describe '#hostname' do
+      it "reports validness of a hostname in silent mode" do
+        subject.silent = true
+        expect(subject.hostname('100')).to eq true
+        expect(subject.hostname('suse')).to eq true
+        expect(subject.hostname('suse-01')).to eq true
+        expect(subject.hostname('suse-com')).to eq true
+        expect(subject.hostname('-suse')).to eq false
+        expect(subject.hostname('suse-')).to eq false
+        expect(subject.hostname('!suse')).to eq false
+      end
+
+      it "reports validness of a hostname in silent mode" do
+        subject.silent = false
+        expect(subject.hostname('100')).to eq nil
+        expect(subject.hostname('suse')).to eq nil
+        expect(subject.hostname('suse-01')).to eq nil
+        expect(subject.hostname('suse-com')).to eq nil
+        expect(subject.hostname('-suse')).to be_kind_of ::String
+        expect(subject.hostname('suse-')).to be_kind_of ::String
+        expect(subject.hostname('!suse')).to be_kind_of ::String
+      end
+
+      it "works in a transaction" do
+        errors = subject.verbose_check do |check|
+          check.hostname('suse-1')
+          check.hostname('suse-com')
+        end
+
+        expect(errors).to be_empty
+        errors = subject.verbose_check do |check|
+          check.hostname('suse-1!')
+          check.hostname('suse-com')
+        end
+        expect(errors).not_to be_empty
+
+        flag = subject.silent_check do |check|
+          check.hostname('-suse')
+          check.hostname('suse-')
+        end
+        expect(flag).to eq false
+
+        flag = subject.silent_check do |check|
+          check.hostname('suse')
+          check.hostname('suse-com')
+        end
+        expect(flag).to eq true
+      end
     end
 
-    it "works in a transaction" do
-      flag = subject.silent_check do |check|
-        check.ipv4('100')
-        check.ipv4('192.168.100.100')
+    describe '#unique' do
+      it "reports uniqueness in silent mode" do
+        subject.silent = true
+        expect(subject.unique(['100', '100', '100'])).to eq false
+        expect(subject.not_unique(['100', '100', '100'])).to eq true
       end
+    end
 
-      expect(flag).to eq false
-
-      flag = subject.silent_check do |check|
-        check.ipv4('192.168.100.100')
-        check.ipv4('192.168.100.1')
+    describe '#ipv4_in_network_cidr' do
+      it 'reports if the given IPv4 belongs to the network' do
+        subject.silent = true
+        expect(subject.ipv4_in_network_cidr('192.168.100.1', '192.168.100.0/24')).to eq true
+        expect(subject.ipv4_in_network_cidr('192.168.100.254', '192.168.100.0/24')).to eq true
+        expect(subject.ipv4_in_network_cidr('192.168.100.1', '192.168.100.0/28')).to eq true
+        expect(subject.ipv4_in_network_cidr('192.168.100.14', '192.168.100.0/28')).to eq true
+        expect(subject.ipv4_in_network_cidr('192.168.100.16', '192.168.100.0/28')).to eq false
       end
-
-      expect(flag).to eq true
-      errs = subject.verbose_check do |check|
-        check.ipv4('192.168.100.100')
-        check.ipv4('192.168.100.1')
-      end
-
-      expect(errs).to be_empty
-      errs = subject.verbose_check do |check|
-        check.ipv4('10')
-        check.ipv4('102.100.100.100')
-      end
-      expect(errs).not_to be_empty
     end
   end
 
-  describe '#hostname' do
-    it "reports validness of a hostname in silent mode" do
+  context 'SAP naming tests' do
+    before do
       subject.silent = true
-      expect(subject.hostname('100')).to eq true
-      expect(subject.hostname('suse')).to eq true
-      expect(subject.hostname('suse-01')).to eq true
-      expect(subject.hostname('suse-com')).to eq true
-      expect(subject.hostname('-suse')).to eq false
-      expect(subject.hostname('suse-')).to eq false
-      expect(subject.hostname('!suse')).to eq false
     end
-
-    it "reports validness of a hostname in silent mode" do
-      subject.silent = false
-      expect(subject.hostname('100')).to eq nil
-      expect(subject.hostname('suse')).to eq nil
-      expect(subject.hostname('suse-01')).to eq nil
-      expect(subject.hostname('suse-com')).to eq nil
-      expect(subject.hostname('-suse')).to be_kind_of ::String
-      expect(subject.hostname('suse-')).to be_kind_of ::String
-      expect(subject.hostname('!suse')).to be_kind_of ::String
-    end
-
-    it "works in a transaction" do
-      errors = subject.verbose_check do |check|
-        check.hostname('suse-1')
-        check.hostname('suse-com')
+      describe "#identifier" do
+      it "returns true for valid IDs" do
+        expect(subject.identifier('1Nuremberg')).to eq true
+        expect(subject.identifier('1Nuremberg-A')).to eq true
+        expect(subject.identifier('1Nuremberg_BA')).to eq true
+        expect(subject.identifier('SuSE-1_2')).to eq true
       end
 
-      expect(errors).to be_empty
-      errors = subject.verbose_check do |check|
-        check.hostname('suse-1!')
-        check.hostname('suse-com')
+      it "returns false for invalid IDs" do
+        expect(subject.identifier('Nürnberg')).to eq false
+        expect(subject.identifier('-Nuremberg')).to eq false
+        expect(subject.identifier('_Nuremberg')).to eq false
+        expect(subject.identifier('*WalDorf-1_2/')).to eq false
       end
-      expect(errors).not_to be_empty
+    end
 
-      flag = subject.silent_check do |check|
-        check.hostname('-suse')
-        check.hostname('suse-')
+    describe "#sap_sid" do
+      it "returns true for valid IDs" do
+        expect(subject.sap_sid('X12')).to eq true
       end
-      expect(flag).to eq false
 
-      flag = subject.silent_check do |check|
-        check.hostname('suse')
-        check.hostname('suse-com')
+      it "returns false for invalid IDs" do
+        expect(subject.sap_sid('123')).to eq false
+        expect(subject.sap_sid('NOT')).to eq false
       end
-      expect(flag).to eq true
     end
-  end
 
-  describe '#unique' do
-    it "reports uniqueness in silent mode" do
-      subject.silent = true
-      expect(subject.unique(['100', '100', '100'])).to eq false
-      expect(subject.not_unique(['100', '100', '100'])).to eq true
-    end
-  end
+    describe "#sap_instance_number" do
+      it "returns true for valid numbers" do
+        expect(subject.sap_instance_number('05')).to eq true
+        expect(subject.sap_instance_number('09')).to eq true
+        expect(subject.sap_instance_number('10')).to eq true
+        expect(subject.sap_instance_number('99')).to eq true
+        end
 
-  describe '#ipv4_in_network_cidr' do
-    it 'reports if the given IPv4 belongs to the network' do
-      subject.silent = true
-      expect(subject.ipv4_in_network_cidr('192.168.100.1', '192.168.100.0/24')).to eq true
-      expect(subject.ipv4_in_network_cidr('192.168.100.254', '192.168.100.0/24')).to eq true
-      expect(subject.ipv4_in_network_cidr('192.168.100.1', '192.168.100.0/28')).to eq true
-      expect(subject.ipv4_in_network_cidr('192.168.100.14', '192.168.100.0/28')).to eq true
-      expect(subject.ipv4_in_network_cidr('192.168.100.16', '192.168.100.0/28')).to eq false
-    end
-  end
-
-  describe 'SAP naming tests' do
-    it 'reports if valid SID and site names will be allowed' do
-      subject.silent = true
-      expect(subject.identifier('1Nuremberg')).to eq true
-      expect(subject.identifier('1Nuremberg-A')).to eq true
-      expect(subject.identifier('1Nuremberg_BA')).to eq true
-      expect(subject.identifier('SuSE-1_2')).to eq true
-      expect(subject.sap_sid('X12')).to eq true
-    end
-    it 'reports if invalid SID and site names will be found' do
-      subject.silent = true
-      expect(subject.identifier('Nürnberg')).to eq false
-      expect(subject.identifier('-Nuremberg')).to eq false
-      expect(subject.identifier('_Nuremberg')).to eq false
-      expect(subject.identifier('*WalDorf-1_2/')).to eq false
-      expect(subject.sap_sid('123')).to eq false
-      expect(subject.sap_sid('NOT')).to eq false
-    end
-    it 'reports if valid instance number will be allowed' do
-      subject.silent = true
-      expect(subject.sap_instance_number('05')).to eq true
-      expect(subject.sap_instance_number('09')).to eq true
-      expect(subject.sap_instance_number('10')).to eq true
-      expect(subject.sap_instance_number('99')).to eq true
-    end
-    it 'reports if invalid instance number will be found' do
-      subject.silent = true
-      expect(subject.sap_instance_number('1')).to eq false
-      expect(subject.sap_instance_number('1A')).to eq false
-      expect(subject.sap_instance_number('999')).to eq false
+      it "returns false for invalid numbers" do
+        expect(subject.sap_instance_number('1')).to eq false
+        expect(subject.sap_instance_number('1A')).to eq false
+        expect(subject.sap_instance_number('999')).to eq false
+      end
     end
   end
 end

--- a/test/semantic_checks_test.rb
+++ b/test/semantic_checks_test.rb
@@ -160,7 +160,8 @@ describe SapHA::SemanticChecks do
     end
     it 'reports if valid instance number will be allowed' do
       subject.silent = true
-      expect(subject.sap_instance_number('01')).to eq true
+      expect(subject.sap_instance_number('05')).to eq true
+      expect(subject.sap_instance_number('09')).to eq true
       expect(subject.sap_instance_number('10')).to eq true
       expect(subject.sap_instance_number('99')).to eq true
     end


### PR DESCRIPTION
## Problem
Valid SAP instance number is not recognized as valid.
- https://bugzilla.suse.com/show_bug.cgi?id=1202979
The SAP instance number must contains 2 digits and it is in the range from 00 to 99.
Integer numbers starting with 0 are interpreted by Ruby as octal numbers. Therefore 08 and 09 are not recognized as valid.

yast2-sap-ha: S:M:24423:276258: csync2 configuration not enabled
- https://bugzilla.suse.com/show_bug.cgi?id=1202112

## Solution

Use a regex to validate the SAP instance number:
SAP_INST_NUM_REGEX = Regexp.new('^[0-9]{2}$')

During the installation csync2.socket will be started and enabled in %post.
It is not enough to enable/start csync2 in code. yast2-sap-ha will be only installed on the additional nodes, but will not be started.
