### PR TITLE
Using ruby base64 to replace uuencode/uudecode

### DIFF
--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 22 09:47:04 UTC 2022 - Peter Varkoly <varkoly@suse.com>
+
+- Use ruby base64 to replace uuencode/uudecode
+  (bsc#1206601)
+- 1.0.17
+
+-------------------------------------------------------------------
 Tue Sep  6 10:06:08 UTC 2022 - Peter Varkoly <varkoly@suse.com>
 
 - YaST2 HA Setup for SAP Products - cannot input several instance numbers

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        1.0.16
+Version:        1.0.17
 Release:        0
 
 BuildArch:      noarch

--- a/src/lib/sap_ha/system/local.rb
+++ b/src/lib/sap_ha/system/local.rb
@@ -150,8 +150,8 @@ module SapHA
         begin
           File.write(CSYNC2_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared csync2 authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared csync2 authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared csync2 authentication key. Error: #{error}")
         end
       end
 
@@ -181,8 +181,8 @@ module SapHA
         begin
           File.write(COROSYNC_KEY_PATH, Base64.decode64(data))
           NodeLogger.info("Wrote the shared corosync secure authentication key")
-        rescue
-          NodeLogger.error("Could not write the shared corosync secure authentication key")
+        rescue => error
+          NodeLogger.error("Could not write the shared corosync secure authentication key. Error: #{error}")
         end
       end
 


### PR DESCRIPTION
## Problem

*yast2-sap-ha uses uuencode and uudecode but do not requires sharutils*

- https://bugzilla.suse.com/show_bug.cgi?id=1206601

## Solution

*Code rewrite: Using ruby base64 instead*
