### PR TITLE
Fix bsc#1221049

### DIFF
--- a/package/yast2-sap-ha.changes
+++ b/package/yast2-sap-ha.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 15 17:38:52 UTC 2024 - Peter Varkoly <varkoly@suse.com>
+
+- yast2-sap-ha: Error occurred during the unattended installation: undefined class/module SapHA::Configuration::ClusterFinalizer
+  (bsc#1221049)
+- 4.5.11
+
+-------------------------------------------------------------------
 Wed Nov 29 07:52:36 UTC 2023 - Peter Varkoly <varkoly@suse.com>
 
 - yast2-sap-ha setup workflow is bad (bsc#1217596)

--- a/package/yast2-sap-ha.spec
+++ b/package/yast2-sap-ha.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sap-ha
-Version:        4.5.10
+Version:        4.5.11
 Release:        0
 BuildArch:      noarch
 Source0:        %{name}-%{version}.tar.bz2

--- a/src/lib/sap_ha/configuration/hana.rb
+++ b/src/lib/sap_ha/configuration/hana.rb
@@ -353,7 +353,7 @@ module SapHA
           add_plugin_to_global_ini("SUS_TKOVER", @system_id)
         end
         command = ["hdbnsutil", "-reloadHADRProviders"]
-        _out, _status = su_exec_outerr_status("#{@system_id.downcase}adm", *command)
+        su_exec_outerr_status("#{@system_id.downcase}adm", *command)
       end
 
       # Activates the plugin in global ini

--- a/src/lib/sap_ha/wizard/scenario_selection_page.rb
+++ b/src/lib/sap_ha/wizard/scenario_selection_page.rb
@@ -42,8 +42,12 @@ module SapHA
       end
 
       def refresh_view
-        previous_configs = SapHA::Helpers.get_configuration_files(@model.product_id)
-        previous_configs_popup(previous_configs) if !previous_configs.empty?
+        begin
+          previous_configs = SapHA::Helpers.get_configuration_files(@model.product_id)
+          previous_configs_popup(previous_configs) if !previous_configs.empty?
+	rescue StandardError => e
+          log.info "Could not parse previous config files: #{e.message}"
+	end
       end
 
       def can_go_next?


### PR DESCRIPTION
## Problem

*When configuration was saved befor installing last version the module can not be started.*
The reason is that the class SapHA::Configuration::ClusterFinalizer was removed and implemented as a function of the class SapHA::Configuration::Hana

- *https://bugzilla.suse.com/show_bug.cgi?id=1221049*

## Solution

*Catch error when the configuration file could not be parsed.*